### PR TITLE
update recipe conditions key

### DIFF
--- a/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_osmium_ingot_to_dust.json
+++ b/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_osmium_ingot_to_dust.json
@@ -10,7 +10,7 @@
     }
   ],
   "energy_mod": 0.5,
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "thermal"

--- a/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_platinum_ingot_to_dust.json
+++ b/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_platinum_ingot_to_dust.json
@@ -10,7 +10,7 @@
     }
   ],
   "energy_mod": 0.5,
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "thermal"

--- a/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_platinum_ore.json
+++ b/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_platinum_ore.json
@@ -18,7 +18,7 @@
     }
   ],
   "experience": 0.2,
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "thermal"

--- a/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_zinc_ingot_to_dust.json
+++ b/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_zinc_ingot_to_dust.json
@@ -10,7 +10,7 @@
     }
   ],
   "energy_mod": 0.5,
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "thermal"

--- a/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_zinc_ore.json
+++ b/src/main/resources/data/alltheores/recipe/thermal_pulverize/pulverizer_zinc_ore.json
@@ -18,7 +18,7 @@
     }
   ],
   "experience": 0.2,
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "thermal"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/aluminum/aluminum_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/aluminum/aluminum_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:aluminum",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/aluminum/aluminum_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/aluminum/aluminum_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:aluminum",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/aluminum/aluminum_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/aluminum/aluminum_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:aluminum",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/lead/lead_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/lead/lead_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:lead",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/lead/lead_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/lead/lead_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:lead",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/lead/lead_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/lead/lead_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:lead",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/nickel/nickel_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/nickel/nickel_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:nickel",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/nickel/nickel_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/nickel/nickel_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:nickel",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/nickel/nickel_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/nickel/nickel_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:nickel",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/osmium/osmium_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/osmium/osmium_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:osmium",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/osmium/osmium_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/osmium/osmium_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:osmium",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/osmium/osmium_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/osmium/osmium_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:osmium",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/platinum/platinum_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/platinum/platinum_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:platinum",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/platinum/platinum_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/platinum/platinum_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:platinum",
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/platinum/platinum_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/platinum/platinum_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:platinum",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/silver/silver_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/silver/silver_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:silver",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/silver/silver_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/silver/silver_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:silver",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/silver/silver_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/silver/silver_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:silver",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/tin/tin_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/tin/tin_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:tin",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/tin/tin_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/tin/tin_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:tin",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/tin/tin_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/tin/tin_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:tin",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/uranium/uranium_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/uranium/uranium_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:uranium",
-  "conditions": [
+  "neoforge:conditions": [
     {
       "type": "neoforge:mod_loaded",
       "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/uranium/uranium_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/uranium/uranium_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:uranium",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/uranium/uranium_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/uranium/uranium_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:uranium",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/zinc/zinc_from_block.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/zinc/zinc_from_block.json
@@ -6,7 +6,7 @@
   "value": 9,
   "needed": 1,
   "material": "alltheores:zinc",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/zinc/zinc_from_ingot.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/zinc/zinc_from_ingot.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 1,
   "material": "alltheores:zinc",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"

--- a/src/main/resources/data/alltheores/recipe/tools_materials/zinc/zinc_from_nugget.json
+++ b/src/main/resources/data/alltheores/recipe/tools_materials/zinc/zinc_from_nugget.json
@@ -6,7 +6,7 @@
   "value": 1,
   "needed": 9,
   "material": "alltheores:zinc",
-  "conditions": [
+  "neoforge:conditions": [
       {
           "type": "neoforge:mod_loaded",
           "modid": "tconstruct"


### PR DESCRIPTION
This fixes recipe parsing errors when the required mods are not loaded. The recipe conditions key was changed in NeoForge.